### PR TITLE
Simplify IfThenElse and CompareSelect within for-loop

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -4438,7 +4438,7 @@ TEST(LoopNest, OptimizeConditionalsMultipleStoresInOneLoop) {
       R"IR(
 # CHECK: for (int i = 0; i < 5
 # CHECK-NEXT: A[i] = B[i]
-# CHECK-NEXT: B[i] = IfThenElse(i<30 ? 1 : 0, C[i], D[i])
+# CHECK-NEXT: B[i] = C[i]
 # CHECK: for (int i = 0; i < 45
 # CHECK-NEXT: A[i + 5] = C[i]
 # CHECK-NEXT: B[i + 5] = IfThenElse(i + 5<30 ? 1 : 0, C[i + 5], D[i + 5])

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4824,6 +4824,148 @@ TEST(Simplify, SimplifyBroadcastTermExpander) {
   }
 }
 
+TEST(Simplify, CompareSelectLoopBounds) {
+  // Before:
+  //   for (const auto n : c10::irange(1, N)) {
+  //     b[n] = n < 1 ? 0.f : 1.f;
+  //   }
+  // After:
+  //   for (const auto n : c10::irange(1, N)) {
+  //     b[n] = 1.f;
+  //   }
+  constexpr int N = 8;
+  BufHandle b("b", {N}, kFloat);
+  VarHandle n("n", kInt);
+
+  auto test_case_fn = [](const VarHandle& n,
+                         const BufHandle& b,
+                         const int& start,
+                         const int& stop,
+                         const int& cmp_val,
+                         const CompareSelectOperation& cmp_op,
+                         const std::string& check_string) {
+    StmtPtr s = For::make(
+        n,
+        start,
+        stop,
+        b.store({n}, CompareSelect::make(n, cmp_val, 0.f, 1.0f, cmp_op)));
+    s = IRSimplifier::simplify(s);
+    std::ostringstream oss;
+    oss << *s;
+    std::string target_string = "# CHECK: ";
+    target_string += check_string;
+    torch::jit::testing::FileCheck().run(target_string, oss.str());
+  };
+
+  // for n in [1...7]
+  //   n < 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kLT, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n <= 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kLE, "b[n] = n<=1 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n <= 0 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 0, kLE, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n < 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kLT, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n < 8 ? 0.f : 1.f => n <= 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N, kLT, "b[n] = 0.f;");
+
+  // for n in [1...7]
+  //   n <= 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N - 1, kLE, "b[n] = 0.f;");
+
+  // for n in [1...7]
+  //   n <= 8 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N, kLE, "b[n] = 0.f;");
+
+  // for n in [1...7]
+  //   n < 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N - 1, kLT, "b[n] = n<7 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n > 0 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 0, kGT, "b[n] = 0.f;");
+
+  // for n in [1...7]
+  //   n > 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kGT, "b[n] = n>1 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n >= 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kGE, "b[n] = 0.f;");
+
+  // for n in [1...7]
+  //   n > 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N - 1, kGT, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n >= 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N - 1, kGE, "b[n] = n>=7 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n > 5 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 5, kGT, "b[n] = n>5 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n >= 5 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 5, kGE, "b[n] = n>=5 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n > 8 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N, kGT, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n >= 8 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N, kGE, "b[n] = 1.f;");
+
+  // for n in [1...1]
+  //   n == 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, 2, 1, kEQ, "b[1] = 0.f;");
+
+  // for n in [1...7]
+  //   n == 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kEQ, "b[n] = n==1 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n == 0 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 0, kEQ, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n == 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N - 1, kEQ, "b[n] = n==7 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n == 8 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N, kEQ, "b[n] = 1.f;");
+
+  // for n in [1...7]
+  //   n != 1 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 1, kNE, "b[n] = n!=1 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n != 7 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N - 1, kNE, "b[n] = n!=7 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n != 5 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 5, kNE, "b[n] = n!=5 ? 0.f : 1.f;");
+
+  // for n in [1...7]
+  //   n != 0 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, 0, kNE, "b[n] = 0.f;");
+
+  // for n in [1...7]
+  //   n != 8 ? 0.f : 1.f
+  test_case_fn(n, b, 1, N, N, kNE, "b[n] = 0.f;");
+}
+
 TEST(Simplify, CompareSelectCondAlwaysInLoopBounds) {
   // Before:
   //   for (const auto n : c10::irange(1, N)) {

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4117,11 +4117,12 @@ TEST(Simplify, SimplifyReorderForCond) {
         0,
         4,
         Cond::make(
-            CompareSelect::make(i, 10, CompareSelectOperation::kLT),
+            CompareSelect::make(i, 3, CompareSelectOperation::kLT),
             Store::make(c, {i}, Load::make(a, {i})),
             nullptr));
 
     StmtPtr simplified = IRSimplifier::simplify(body);
+
     IS_NODE_WITH_NAME(For, simplified, loop);
     IS_NODE_WITH_NAME(Cond, loop->body()->front(), cond);
   }
@@ -4234,7 +4235,7 @@ TEST(Simplify, SimplifyReorderForCond) {
             CompareSelect::make(
                 Load::make(a, {0}), 10, CompareSelectOperation::kLT),
             Cond::make(
-                CompareSelect::make(i, 10, CompareSelectOperation::kEQ),
+                CompareSelect::make(i, 3, CompareSelectOperation::kEQ),
                 Store::make(c, {0}, Load::make(a, {i})),
                 nullptr),
             nullptr));

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4117,12 +4117,11 @@ TEST(Simplify, SimplifyReorderForCond) {
         0,
         4,
         Cond::make(
-            CompareSelect::make(i, 3, CompareSelectOperation::kLT),
+            CompareSelect::make(i, 2, CompareSelectOperation::kEQ),
             Store::make(c, {i}, Load::make(a, {i})),
             nullptr));
 
     StmtPtr simplified = IRSimplifier::simplify(body);
-
     IS_NODE_WITH_NAME(For, simplified, loop);
     IS_NODE_WITH_NAME(Cond, loop->body()->front(), cond);
   }
@@ -4845,6 +4844,17 @@ TEST(Simplify, CompareSelectCondAlwaysInLoopBounds) {
   torch::jit::testing::FileCheck().run(
       R"IR(
 # CHECK: b[n] = 1.f;
+)IR",
+      oss.str());
+
+  s = For::make(
+      n, 1, N, b.store({n}, CompareSelect::make(n, N, 0.f, 1.0f, kLT)));
+  s = IRSimplifier::simplify(s);
+  oss.clear();
+  oss << *s;
+  torch::jit::testing::FileCheck().run(
+      R"IR(
+# CHECK: b[n] = 0.f;
 )IR",
       oss.str());
 }

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4824,7 +4824,7 @@ TEST(Simplify, SimplifyBroadcastTermExpander) {
   }
 }
 
-TEST(Simplify, bound_CompareSelectCondAlwaysInLoopBounds) {
+TEST(Simplify, CompareSelectCondAlwaysInLoopBounds) {
   // Before:
   //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = n < 1 ? 0.f : 1.f;
@@ -4848,7 +4848,7 @@ TEST(Simplify, bound_CompareSelectCondAlwaysInLoopBounds) {
       oss.str());
 }
 
-TEST(Simplify, bound_IfThenCondAlwaysInLoopBounds) {
+TEST(Simplify, IfThenCondAlwaysInLoopBounds) {
   // Before:
   //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = IfThenElse(n < 1 ? 1 : 0, 0.f, 1.f);
@@ -4872,7 +4872,7 @@ TEST(Simplify, bound_IfThenCondAlwaysInLoopBounds) {
       oss.str());
 }
 
-TEST(Simplify, bound_MultiClauseCondAlwaysInLoopBounds) {
+TEST(Simplify, MultiClauseCondAlwaysInLoopBounds) {
   // This test mimics the unpadded region of a conv2d.  We want to remove any
   // conditional that is provably satisfied (or unsatisfied) by the entire loop
   // range.
@@ -4906,7 +4906,7 @@ TEST(Simplify, bound_MultiClauseCondAlwaysInLoopBounds) {
       oss.str());
 }
 
-TEST(Simplify, bound_SimplifyLoopBounds) {
+TEST(Simplify, DISABLED_SimplifyLoopBounds) {
   // This test mimics the padded region of a conv2d.  We want to adjust the
   // loop bounds such that the condition will be always met.  Note that this
   // could be solved by peeling, and applying the range-based conditional

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4988,17 +4988,6 @@ TEST(Simplify, CompareSelectCondAlwaysInLoopBounds) {
 # CHECK: b[n] = 1.f;
 )IR",
       oss.str());
-
-  s = For::make(
-      n, 1, N, b.store({n}, CompareSelect::make(n, N, 0.f, 1.0f, kLT)));
-  s = IRSimplifier::simplify(s);
-  oss.clear();
-  oss << *s;
-  torch::jit::testing::FileCheck().run(
-      R"IR(
-# CHECK: b[n] = 0.f;
-)IR",
-      oss.str());
 }
 
 TEST(Simplify, IfThenCondAlwaysInLoopBounds) {

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4824,7 +4824,7 @@ TEST(Simplify, SimplifyBroadcastTermExpander) {
   }
 }
 
-TEST(Simplify, DISABLED_CompareSelectCondAlwaysInLoopBounds) {
+TEST(Simplify, bound_CompareSelectCondAlwaysInLoopBounds) {
   // Before:
   //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = n < 1 ? 0.f : 1.f;
@@ -4848,7 +4848,7 @@ TEST(Simplify, DISABLED_CompareSelectCondAlwaysInLoopBounds) {
       oss.str());
 }
 
-TEST(Simplify, DISABLED_IfThenCondAlwaysInLoopBounds) {
+TEST(Simplify, bound_IfThenCondAlwaysInLoopBounds) {
   // Before:
   //   for (const auto n : c10::irange(1, N)) {
   //     b[n] = IfThenElse(n < 1 ? 1 : 0, 0.f, 1.f);
@@ -4872,7 +4872,7 @@ TEST(Simplify, DISABLED_IfThenCondAlwaysInLoopBounds) {
       oss.str());
 }
 
-TEST(Simplify, DISABLED_MultiClauseCondAlwaysInLoopBounds) {
+TEST(Simplify, bound_MultiClauseCondAlwaysInLoopBounds) {
   // This test mimics the unpadded region of a conv2d.  We want to remove any
   // conditional that is provably satisfied (or unsatisfied) by the entire loop
   // range.
@@ -4901,12 +4901,12 @@ TEST(Simplify, DISABLED_MultiClauseCondAlwaysInLoopBounds) {
   oss << *s;
   torch::jit::testing::FileCheck().run(
       R"IR(
-# CHECK: b[n] = 1.f;
+# CHECK: b[i, j] = 1.f;
 )IR",
       oss.str());
 }
 
-TEST(Simplify, DISABLED_SimplifyLoopBounds) {
+TEST(Simplify, bound_SimplifyLoopBounds) {
   // This test mimics the padded region of a conv2d.  We want to adjust the
   // loop bounds such that the condition will be always met.  Note that this
   // could be solved by peeling, and applying the range-based conditional

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -4870,7 +4870,7 @@ TEST(Simplify, CompareSelectLoopBounds) {
   test_case_fn(n, b, 1, N, 0, kLE, "b[n] = 1.f;");
 
   // for n in [1...7]
-  //   n < 1 ? 0.f : 1.f
+  //   n < 0 ? 0.f : 1.f
   test_case_fn(n, b, 1, N, 1, kLT, "b[n] = 1.f;");
 
   // for n in [1...7]

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -11,6 +11,8 @@ namespace jit {
 namespace tensorexpr {
 namespace analysis {
 
+using BoundCompareResult = CompareSelectOperation;
+
 // A simple class containing the start and end of a range in a single dimension.
 struct TORCH_API Bound {
   ExprPtr start{nullptr};
@@ -60,6 +62,12 @@ enum OverlapKind { ContainedOrEqual, Contains, PartialOverlap, NoOverlap };
 // Returns the kind of overlap between Bound A and Bound A in a single
 // dimension.
 OverlapKind TORCH_API boundOverlap(Bound A, Bound B);
+
+// Return true if the logic as follows is always satisfied:
+//    (a < b) / (a <= b) / (a > b) / (a >= b) / (a == b) / (a != b)
+// Otherwise, it returns false.
+bool TORCH_API
+compareBound(const Bound& a, const Bound& b, BoundCompareResult& cmp_result);
 
 // A multi dimensional bound representing the bound of a set of indices.
 using IndexBounds = std::vector<Bound>;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -3029,24 +3029,23 @@ ExprPtr SimplifierUnderContext::mutate(CompareSelectPtr v) {
     TORCH_INTERNAL_ASSERT(
         (overlap_kind == analysis::OverlapKind::Contains) ||
         (overlap_kind == analysis::OverlapKind::ContainedOrEqual));
-    TORCH_INTERNAL_ASSERT(
-        exprEquals(lhs_bound.start, lhs_bound.end) ||
-        exprEquals(rhs_bound.start, rhs_bound.end));
     if (exprEquals(lhs_bound.end, rhs_bound.start)) {
       // lhs = [5, 5] and rhs = [5, 10]
       // lhs = [5, 10] and rhs = [10, 10]
       cmp_res = CompareResult::kLE;
+      return true;
     } else if (exprEquals(lhs_bound.start, rhs_bound.end)) {
       // lhs = [10, 10] and rhs = [5, 10]
       // lhs = [5, 10] and rhs = [5, 5]
       cmp_res = CompareResult::kGE;
+      return true;
     } else {
       // lhs = [8, 8] and rhs = [5, 10]
       // lhs = [5, 10] and rhs = [8, 8]
+      // lhs = [5, 10] and rhs = [6, 7]
+      // lhs = [6, 7] and rhs = [5, 10]
       return false;
     }
-
-    return (cmp_res == CompareResult::kLE) || (cmp_res == CompareResult::kGE);
   };
 
   analysis::Bound lhs_bound;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -3086,14 +3086,18 @@ ExprPtr SimplifierUnderContext::mutate(CompareSelectPtr v) {
           : simp_ret2;
       break;
     case CompareSelectOperation::kNE:
-      ret_expr = (cmp_res != CompareSelectOperation::kEQ)
+      ret_expr = (cmp_res == CompareSelectOperation::kGT ||
+                  cmp_res == CompareSelectOperation::kLT)
           ? simp_ret1
           : simplified_cmp_select_expr;
       break;
     case CompareSelectOperation::kEQ:
       ret_expr = (cmp_res == CompareSelectOperation::kEQ)
           ? simp_ret1
-          : simplified_cmp_select_expr;
+          : ((cmp_res == CompareSelectOperation::kGT ||
+              cmp_res == CompareSelectOperation::kLT)
+                 ? simp_ret2
+                 : simplified_cmp_select_expr);
       break;
     default:
       TORCH_INTERNAL_ASSERT(false);

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -3081,8 +3081,7 @@ ExprPtr SimplifierUnderContext::mutate(CompareSelectPtr v) {
       break;
   }
 
-  GRAPH_DEBUG(
-      "(SimplifierUnderContext) after simplify: ", std::to_string(ret_expr));
+  GRAPH_DEBUG("(SimplifierUnderContext) Final: ", std::to_string(ret_expr));
   return ret_expr;
 }
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -2916,19 +2916,23 @@ ExprPtr SimplifierUnderContext::mutate(IfThenElsePtr v) {
   ExprPtr true_val = v->true_value();
   ExprPtr false_val = v->false_value();
 
-  auto simp_condition = IRSimplifier::simplify(condition->accept_mutator(this));
-  auto simp_true_val = IRSimplifier::simplify(true_val->accept_mutator(this));
-  auto simp_false_val = IRSimplifier::simplify(false_val->accept_mutator(this));
-  if (simp_condition->isConstant()) {
-    return immediateAs<int>(simp_condition) ? simp_true_val : simp_false_val;
+  auto simplified_condition =
+      IRSimplifier::simplify(condition->accept_mutator(this));
+  auto simplified_true_val =
+      IRSimplifier::simplify(true_val->accept_mutator(this));
+  auto simplified_false_val =
+      IRSimplifier::simplify(false_val->accept_mutator(this));
+  if (simplified_condition->isConstant()) {
+    return immediateAs<int>(simplified_condition) ? simplified_true_val
+                                                  : simplified_false_val;
   }
 
-  ExprPtr simplified_ifelse_expr = nullptr;
-  bool nothing_changed = (simp_condition == condition) &&
-      (simp_true_val == true_val) && (simp_false_val == false_val);
+  bool nothing_changed = (simplified_condition == condition) &&
+      (simplified_true_val == true_val) && (simplified_false_val == false_val);
   return nothing_changed
       ? v
-      : alloc<IfThenElse>(simp_condition, simp_true_val, simp_false_val);
+      : alloc<IfThenElse>(
+            simplified_condition, simplified_true_val, simplified_false_val);
 }
 
 ExprPtr SimplifierUnderContext::mutate(CompareSelectPtr v) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -373,6 +373,10 @@ class MinTerm : public ExprNode<MinTerm> {
 
 // Context-sensitive IR simplification
 using VarBoundInfo = std::unordered_map<VarPtr, std::pair<ExprPtr, ExprPtr>>;
+namespace analysis {
+class Bound;
+};
+
 class TORCH_API SimplifierUnderContext : public IRMutator {
  public:
   ~SimplifierUnderContext() override = default;
@@ -383,6 +387,9 @@ class TORCH_API SimplifierUnderContext : public IRMutator {
   ExprPtr mutate(ModPtr v) override;
   ExprPtr mutate(CompareSelectPtr v) override;
   ExprPtr mutate(IfThenElsePtr v) override;
+
+ protected:
+  bool getBoundInfo(const ExprPtr& expr, analysis::Bound* bound_info);
 
  protected:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -381,6 +381,8 @@ class TORCH_API SimplifierUnderContext : public IRMutator {
 
   ExprPtr mutate(DivPtr v) override;
   ExprPtr mutate(ModPtr v) override;
+  ExprPtr mutate(CompareSelectPtr v) override;
+  ExprPtr mutate(IfThenElsePtr v) override;
 
  protected:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)


### PR DESCRIPTION
Analyze the range to determine if a condition cannot be satisfied. Suppose the for-loop body contains `IfThenElse` or `CompareSelect` while the condition of the two statements depends on the for-loop index `Var`. In that case, we will analyze the range to check whether the condition could always be satisfied or not. If the condition is deterministic, simplify the logic.
